### PR TITLE
Implement mobile burger menu for header navigation

### DIFF
--- a/src/assets/apps-rectangle.svg
+++ b/src/assets/apps-rectangle.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="7" width="20" height="2.8" rx="1.4" fill="#F8F9FB" />
+  <rect x="4" y="13" width="20" height="2.8" rx="1.4" fill="#F8F9FB" />
+  <rect x="4" y="19" width="20" height="2.8" rx="1.4" fill="#F8F9FB" />
+</svg>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -32,36 +32,91 @@ const link = (anchor: string) => (isHome ? anchor : `/${anchor}`);
     document.querySelectorAll('.navbar').forEach((navbar) => {
       const toggle = navbar.querySelector('.nav-toggle');
       const navLinks = navbar.querySelector('.nav-links');
+      const navElement = navbar.closest('nav');
 
       if (!(toggle instanceof HTMLButtonElement) || !(navLinks instanceof HTMLElement)) {
         return;
       }
 
-      const closeMenu = () => {
-        toggle.setAttribute('aria-expanded', 'false');
-        toggle.setAttribute('aria-label', 'Открыть меню');
-        navLinks.classList.remove('is-open');
+      const setMenuState = (isOpen: boolean) => {
+        toggle.setAttribute('aria-expanded', String(isOpen));
+        toggle.setAttribute('aria-label', isOpen ? 'Закрыть меню' : 'Открыть меню');
+        navbar.classList.toggle('is-open', isOpen);
+        navElement?.classList.toggle('is-open', isOpen);
+        navLinks.classList.toggle('is-open', isOpen);
+        document.body.classList.toggle('nav-is-open', isOpen);
       };
+
+      navbar.classList.add('has-collapsible-nav');
+
+      const closeMenu = (focusToggle = false) => {
+        setMenuState(false);
+
+        if (focusToggle) {
+          toggle.focus();
+        }
+      };
+
+      setMenuState(false);
 
       toggle.addEventListener('click', () => {
         const expanded = toggle.getAttribute('aria-expanded') === 'true';
         const nextExpanded = !expanded;
 
-        toggle.setAttribute('aria-expanded', String(nextExpanded));
-        toggle.setAttribute('aria-label', nextExpanded ? 'Закрыть меню' : 'Открыть меню');
-        navLinks.classList.toggle('is-open', nextExpanded);
+        setMenuState(nextExpanded);
       });
 
       navLinks.querySelectorAll('a').forEach((link) => {
         link.addEventListener('click', closeMenu);
       });
 
+      navbar.addEventListener('click', (event) => {
+        if (!navbar.classList.contains('is-open')) {
+          return;
+        }
+
+        const target = event.target;
+
+        if (!(target instanceof Node)) {
+          return;
+        }
+
+        if (navLinks.contains(target)) {
+          return;
+        }
+
+        const navMain = navbar.querySelector('.nav-main');
+
+        if (navMain instanceof HTMLElement && navMain.contains(target)) {
+          return;
+        }
+
+        closeMenu();
+      });
+
+      const handleKeydown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          closeMenu(true);
+        }
+      };
+
+      document.addEventListener('keydown', handleKeydown);
+
       const desktopMediaQuery = window.matchMedia('(min-width: 769px)');
-      desktopMediaQuery.addEventListener('change', (event) => {
+      const handleViewportChange = (event: MediaQueryListEvent) => {
         if (event.matches) {
           closeMenu();
         }
-      });
+      };
+
+      desktopMediaQuery.addEventListener('change', handleViewportChange);
+
+      const cleanup = () => {
+        document.removeEventListener('keydown', handleKeydown);
+        desktopMediaQuery.removeEventListener('change', handleViewportChange);
+      };
+
+      window.addEventListener('beforeunload', cleanup, { once: true });
     });
   });
 </script>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,18 +1,24 @@
 ---
 import logoUrl from '@assets/logo.svg?url';
+import menuIconUrl from '@assets/apps-rectangle.svg?url';
 
 const isHome = Astro.url.pathname === '/';
 const link = (anchor: string) => (isHome ? anchor : `/${anchor}`);
 ---
 <nav>
   <div class="navbar">
-    <a class="nav-brand" href="/" aria-label="Flexagon Technologies — на главную">
-      <span class="nav-logo">
-        <img src={logoUrl} alt="Flexagon Technologies" width="140" height="48" loading="lazy" />
-      </span>
-      <span class="nav-title" role="heading" aria-level="1">Flexagon Technologies</span>
-    </a>
-    <div class="nav-links">
+    <div class="nav-main">
+      <a class="nav-brand" href="/" aria-label="Flexagon Technologies — на главную">
+        <span class="nav-logo">
+          <img src={logoUrl} alt="Flexagon Technologies" width="140" height="48" loading="lazy" />
+        </span>
+        <span class="nav-title" role="heading" aria-level="1">Flexagon Technologies</span>
+      </a>
+      <button class="nav-toggle" type="button" aria-label="Открыть меню" aria-controls="nav-menu" aria-expanded="false">
+        <img src={menuIconUrl} alt="" aria-hidden="true" width="28" height="28" loading="lazy" />
+      </button>
+    </div>
+    <div class="nav-links" id="nav-menu">
       <a href={link('#services')}>Услуги</a>
       <a href={link('#tech')}>Технологии</a>
       <a href={link('#process')}>Процесс</a>
@@ -21,3 +27,41 @@ const link = (anchor: string) => (isHome ? anchor : `/${anchor}`);
     </div>
   </div>
 </nav>
+<script type="module">
+  document.addEventListener('astro:load', () => {
+    document.querySelectorAll('.navbar').forEach((navbar) => {
+      const toggle = navbar.querySelector('.nav-toggle');
+      const navLinks = navbar.querySelector('.nav-links');
+
+      if (!(toggle instanceof HTMLButtonElement) || !(navLinks instanceof HTMLElement)) {
+        return;
+      }
+
+      const closeMenu = () => {
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.setAttribute('aria-label', 'Открыть меню');
+        navLinks.classList.remove('is-open');
+      };
+
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        const nextExpanded = !expanded;
+
+        toggle.setAttribute('aria-expanded', String(nextExpanded));
+        toggle.setAttribute('aria-label', nextExpanded ? 'Закрыть меню' : 'Открыть меню');
+        navLinks.classList.toggle('is-open', nextExpanded);
+      });
+
+      navLinks.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', closeMenu);
+      });
+
+      const desktopMediaQuery = window.matchMedia('(min-width: 769px)');
+      desktopMediaQuery.addEventListener('change', (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      });
+    });
+  });
+</script>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -33,6 +33,12 @@ nav {
   gap: clamp(0.9rem, 3vw, 1.8rem);
 }
 
+.nav-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .nav-brand {
   display: inline-flex;
   align-items: center;
@@ -44,6 +50,35 @@ nav {
 .nav-brand:hover,
 .nav-brand:focus {
   text-decoration: none;
+}
+
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(74, 183, 22, 0.45);
+  background: rgba(17, 18, 22, 0.65);
+  color: var(--color-light);
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.nav-toggle:hover {
+  background: rgba(74, 183, 22, 0.18);
+  border-color: rgba(140, 255, 120, 0.7);
+}
+
+.nav-toggle:focus-visible {
+  outline: 2px solid rgba(140, 255, 120, 0.75);
+  outline-offset: 2px;
+}
+
+.nav-toggle img {
+  width: 24px;
+  height: 24px;
 }
 
 .nav-logo {
@@ -198,26 +233,56 @@ footer a {
 
   .navbar {
     flex-direction: column;
-    align-items: center;
-    gap: 1.2rem;
-    text-align: center;
+    align-items: stretch;
+    gap: 0.9rem;
+    text-align: left;
     padding: 0.8rem 1rem;
   }
 
-  .nav-brand {
+  .nav-main {
     width: 100%;
-    justify-content: center;
+    justify-content: space-between;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .nav-brand {
+    width: auto;
+    justify-content: flex-start;
   }
 
   .nav-links {
     width: 100%;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.8rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
+    padding-right: 0;
+    display: none;
+  }
+
+  .nav-links.is-open {
+    display: flex;
   }
 
   .nav-links a {
-    padding: 0.45rem 0.75rem;
+    display: block;
+    width: 100%;
+    padding: 0.55rem 0.8rem;
+    border-radius: var(--radius-md);
+    text-align: left;
+    transition: color 0.2s ease, background 0.2s ease;
+  }
+
+  .nav-links a:hover {
+    background: rgba(74, 183, 22, 0.24);
+  }
+
+  .nav-links a:focus-visible {
+    outline: none;
+    background: rgba(74, 183, 22, 0.28);
+    color: var(--color-light);
   }
 
   .hero {
@@ -248,13 +313,13 @@ footer a {
 
   .navbar {
     padding: 0.7rem 0.85rem;
-    gap: 0.9rem;
+    gap: 0.75rem;
   }
 
   .nav-brand {
     flex-direction: row;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 0.55rem;
   }
 
@@ -266,7 +331,7 @@ footer a {
 
   .nav-title {
     font-size: 0.9rem;
-    text-align: center;
+    text-align: left;
   }
 
   .hero {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -21,6 +21,10 @@ nav {
   margin: 1.5rem auto;
 }
 
+body.nav-is-open {
+  overflow: hidden;
+}
+
 .navbar {
   display: flex;
   align-items: center;
@@ -231,12 +235,22 @@ footer a {
     margin: 1rem auto 2rem auto;
   }
 
+  nav.is-open {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+  }
+
   .navbar {
     flex-direction: column;
     align-items: stretch;
     gap: 0.9rem;
     text-align: left;
     padding: 0.8rem 1rem;
+  }
+
+  .navbar.has-collapsible-nav {
+    position: relative;
   }
 
   .nav-main {
@@ -259,10 +273,13 @@ footer a {
     align-items: stretch;
     gap: 0.65rem;
     padding-right: 0;
+  }
+
+  .navbar.has-collapsible-nav .nav-links {
     display: none;
   }
 
-  .nav-links.is-open {
+  .navbar.has-collapsible-nav .nav-links.is-open {
     display: flex;
   }
 
@@ -283,6 +300,48 @@ footer a {
     outline: none;
     background: rgba(74, 183, 22, 0.28);
     color: var(--color-light);
+  }
+
+  .navbar.has-collapsible-nav.is-open {
+    position: fixed;
+    inset: 0;
+    margin: 0;
+    border-radius: 0;
+    border: none;
+    background: rgba(17, 18, 22, 0.96);
+    padding: 1.5rem 1.25rem 3rem;
+    gap: 1.5rem;
+    align-items: stretch;
+    justify-content: flex-start;
+    overflow-y: auto;
+    min-height: 100vh;
+    z-index: 120;
+  }
+
+  .navbar.has-collapsible-nav.is-open .nav-main {
+    position: sticky;
+    top: 0;
+    padding-bottom: 1rem;
+    margin-bottom: 0.75rem;
+    background: rgba(17, 18, 22, 0.96);
+    z-index: 1;
+  }
+
+  .navbar.has-collapsible-nav.is-open .nav-links {
+    gap: 0.75rem;
+  }
+
+  .navbar.has-collapsible-nav.is-open .nav-links a {
+    background: rgba(74, 183, 22, 0.08);
+    border: 1px solid rgba(74, 183, 22, 0.35);
+  }
+
+  .navbar.has-collapsible-nav.is-open .nav-links a:hover {
+    background: rgba(74, 183, 22, 0.18);
+  }
+
+  .navbar.has-collapsible-nav.is-open .nav-links a:focus-visible {
+    background: rgba(74, 183, 22, 0.28);
   }
 
   .hero {


### PR DESCRIPTION
## Summary
- add a mobile navigation toggle that swaps the header links to a collapsible burger menu
- wire up accessibility friendly open/close behaviour and reset logic for the mobile menu
- refresh responsive header styles and reuse the new apps-rectangle icon for the toggle button

## Testing
- npm run check *(fails: requires @astrojs/check/typescript packages; installation blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe9d0bdf4832083e59637abe18acc